### PR TITLE
Auto-run verification on install/update and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,29 @@
 
 One-click environment setup and verification for [EECS 280](https://eecs280.org) at the University of Michigan.
 
+## What this extension does
+
+When you install this extension, it automatically:
+
+- **Installs required VS Code extensions:** [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) and [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) for C++ editing and debugging. On Windows, the [WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension is also installed. You may see these appear in your Extensions panel — that's expected.
+- **Applies course-default settings:** disables AI/Copilot features and configures LLDB for the course's debugging workflow.
+- **Runs verification automatically:** on first install and after extension updates, a terminal opens and checks that your development environment is set up correctly. The script will explain any issues it finds and offer to fix them.
+
+It also provides an **EECS 280: Verify Setup** command you can run manually any time you want to re-check your environment.
+
 ## Usage
 
-1. Install this extension from the VS Code Marketplace.
-2. Open the Command Palette: `Cmd+Shift+P` (macOS) or `Ctrl+Shift+P` (Windows/Linux).
-3. Type **EECS 280: Verify Setup** and press Enter.
-4. Follow any prompts in the terminal.
+Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kyukibug.eecs280-setup). Verification runs automatically the first time the extension loads (and again after updates) — a terminal will open and check your environment. Follow any prompts; if the script finds issues, it will explain each one and offer to fix it.
 
-If the script finds issues, it will explain each one and offer to fix it. After fixing, re-run the command to confirm everything passes.
+### Re-running verification manually
+
+To re-check your environment later:
+
+1. Open the Command Palette:
+   - macOS: `Cmd+Shift+P`
+   - Windows/Linux: `Ctrl+Shift+P`
+2. Type **EECS 280: Verify Setup** and press Enter.
+3. Follow any prompts in the terminal.
 
 ## What gets checked
 
@@ -44,6 +59,12 @@ Open VS Code, press `Cmd+Shift+P` (or `Ctrl+Shift+P`), type "Shell Command: Inst
 ## For course staff
 
 This extension is maintained at [github.com/kyukibug/eecs280-setup](https://github.com/kyukibug/eecs280-setup).
+
+Related documentation that references this extension (update alongside changes here):
+
+- [EECS 280 tutorials repo](https://github.com/eecs280staff/tutorials/)
+- [macOS VS Code setup guide](https://github.com/eecs280staff/tutorials/blob/main/docs/setup_vscode_macos.md)
+- [WSL VS Code setup guide](https://github.com/eecs280staff/tutorials/blob/main/docs/setup_vscode_wsl.md)
 
 ---
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,8 @@ import * as fs from "fs";
 //      configurationDefaults in package.json — no code needed here either.
 //   3. Registers the "EECS 280: Verify Setup" command, which detects the
 //      student's OS and runs the appropriate verification script in the
-//      integrated terminal.
+//      integrated terminal. The verification also runs automatically on
+//      first install and after extension updates.
 //
 // Architecture:
 //   - The bash scripts in scripts/ do ALL the heavy lifting (checking tools,
@@ -30,6 +31,11 @@ import * as fs from "fs";
 //   - To change default settings, edit package.json "configurationDefaults".
 //   - To add a new required extension, add it to "extensionDependencies".
 // =============================================================================
+
+/** globalState key tracking the extension version that last triggered an
+ *  auto-run of verification. Used to detect first install (undefined) and
+ *  updates (stored version differs from current). */
+const LAST_VERIFY_VERSION_KEY = "lastVerifyVersion";
 
 /**
  * Detects the current platform from VS Code's perspective.
@@ -111,6 +117,71 @@ function runScriptInTerminal(scriptPath: string): void {
 }
 
 /**
+ * Runs the verification script appropriate for the current platform.
+ *
+ * Shared between the manual "EECS 280: Verify Setup" command and the
+ * automatic run on first install / after updates.
+ *
+ * The `isAutoRun` flag controls behavior for the Windows (non-WSL) case:
+ *   - Manual invocation: shows a warning popup with a link to the WSL
+ *     setup guide, since the student explicitly asked us to verify and
+ *     deserves actionable feedback.
+ *   - Auto-run: silently no-ops, so students who installed the extension
+ *     on a Windows VS Code they use for other projects don't get an
+ *     unprompted warning popup.
+ */
+function runVerificationForPlatform(
+  context: vscode.ExtensionContext,
+  isAutoRun: boolean
+): void {
+  const platform = detectPlatform();
+
+  switch (platform) {
+    case "macos": {
+      runScriptInTerminal(getScriptPath(context, "verify_macos.sh"));
+      break;
+    }
+
+    case "wsl": {
+      runScriptInTerminal(getScriptPath(context, "verify_wsl.sh"));
+      break;
+    }
+
+    case "linux": {
+      runScriptInTerminal(getScriptPath(context, "verify_linux.sh"));
+      break;
+    }
+
+    case "windows": {
+      if (isAutoRun) {
+        // Don't surface an unprompted warning on auto-run.
+        return;
+      }
+      // Student is on Windows but hasn't connected VS Code to WSL.
+      // Show a helpful message explaining what to do.
+      vscode.window
+        .showWarningMessage(
+          "EECS 280 requires WSL (Windows Subsystem for Linux). " +
+            "Please install WSL and Ubuntu, then connect VS Code to WSL " +
+            'by clicking the blue "><" icon in the bottom-left corner ' +
+            'and selecting "Connect to WSL".',
+          "Open WSL Setup Guide"
+        )
+        .then((selection) => {
+          if (selection === "Open WSL Setup Guide") {
+            vscode.env.openExternal(
+              vscode.Uri.parse(
+                "https://eecs280staff.github.io/tutorials/setup_wsl.html"
+              )
+            );
+          }
+        });
+      break;
+    }
+  }
+}
+
+/**
  * Extension activation — called once when the extension is first loaded.
  *
  * This happens when:
@@ -132,54 +203,41 @@ export function activate(context: vscode.ExtensionContext): void {
   const verifyCommand = vscode.commands.registerCommand(
     "eecs280.verifySetup",
     () => {
-      const platform = detectPlatform();
-
-      switch (platform) {
-        case "macos": {
-          const scriptPath = getScriptPath(context, "verify_macos.sh");
-          runScriptInTerminal(scriptPath);
-          break;
-        }
-
-        case "wsl": {
-          const scriptPath = getScriptPath(context, "verify_wsl.sh");
-          runScriptInTerminal(scriptPath);
-          break;
-        }
-
-        case "linux": {
-          const scriptPath = getScriptPath(context, "verify_linux.sh");
-          runScriptInTerminal(scriptPath);
-          break;
-        }
-
-        case "windows": {
-          // Student is on Windows but hasn't connected VS Code to WSL.
-          // Show a helpful message explaining what to do.
-          vscode.window
-            .showWarningMessage(
-              "EECS 280 requires WSL (Windows Subsystem for Linux). " +
-                "Please install WSL and Ubuntu, then connect VS Code to WSL " +
-                'by clicking the blue "><" icon in the bottom-left corner ' +
-                'and selecting "Connect to WSL".',
-              "Open WSL Setup Guide"
-            )
-            .then((selection) => {
-              if (selection === "Open WSL Setup Guide") {
-                vscode.env.openExternal(
-                  vscode.Uri.parse(
-                    "https://eecs280staff.github.io/tutorials/setup_wsl.html"
-                  )
-                );
-              }
-            });
-          break;
-        }
-      }
+      runVerificationForPlatform(context, false);
     }
   );
 
   context.subscriptions.push(verifyCommand);
+
+  // Auto-run verification on first install and after extension updates.
+  //
+  // We compare the version stored in globalState to the extension's current
+  // version. If they differ (including the undefined-vs-version case on
+  // first install), we run the verification script and update the stored
+  // version so subsequent activations of this same version skip the auto-run.
+  //
+  // We update globalState AFTER launching the terminal so that if anything
+  // throws during launch, the next activation will retry rather than silently
+  // marking this version as done.
+  const currentVersion = context.extension.packageJSON.version;
+  const lastRunVersion = context.globalState.get<string>(
+    LAST_VERIFY_VERSION_KEY
+  );
+
+  if (lastRunVersion !== currentVersion) {
+    runVerificationForPlatform(context, true);
+
+    // Only surface the "heads up" notification on platforms where we actually
+    // launched a terminal. On Windows the auto-run is a no-op, so the message
+    // would be misleading.
+    if (detectPlatform() !== "windows") {
+      vscode.window.showInformationMessage(
+        "EECS 280 Setup is verifying your environment in the terminal below."
+      );
+    }
+
+    context.globalState.update(LAST_VERIFY_VERSION_KEY, currentVersion);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1 and #2 

## Changes
- src/extension.ts: Verification now runs automatically on first install and after updates by comparing the current extension version against a value stored in globalState. A notification explains the terminal to students. Windows (non-WSL) auto-run is silently skipped. Refactored the platform switch into a shared helper used by both the manual command and auto-run.
- README.md: Added a "What this extension does" section, restructured Usage to separate install from re-run instructions, and added related documentation links under "For course staff".