### PR TITLE
WSL: Non-WSL VSCode window now opens a WSL VSCode window no matter if in folder or not.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Two ways the verify script gets run:
 
 `detectPlatform()` returns `"macos" | "wsl" | "linux" | "windows"`. WSL is distinguished from native Linux by reading `/proc/version` for `microsoft|wsl`. `"windows"` means VS Code is running native on Windows with no WSL connection — verify scripts cannot run there.
 
-`isWindowsWithUnusedWsl()` is a separate, more specific check: VS Code is on Windows, *not* connected to WSL (`vscode.env.remoteName !== "wsl"`), but `wsl.exe -l -q` reports at least one installed distro. This is the silent-failure mode where the student installed everything in WSL but launched VS Code as a Windows app. We surface a "Reopen in WSL" notification + status bar warning instead of running the script.
+`isWindowsWithUnusedWsl()` is a separate, more specific check: VS Code is on Windows, *not* connected to WSL (`vscode.env.remoteName !== "wsl"`), but `wsl.exe -l -q` reports at least one installed distro. This is the silent-failure mode where the student installed everything in WSL but launched VS Code as a Windows app. We surface a notification + status bar warning instead of running the script. The `eecs280.reopenInWsl` command (and the notification button) are folder-aware: if a workspace folder is open it calls `remote-wsl.reopenInWSL`; if not (the common first-install case) it calls `remote-wsl.newWindow` — `reopenInWSL` silently fails without a folder.
 
 > Note: `wsl.exe -l -q` outputs UTF-16 LE — the code collects bytes and decodes explicitly. Don't switch to a default-encoding string read.
 
@@ -87,6 +87,8 @@ After the install resolves, `activate()` re-checks `getExtension` once more. If 
 ### Auto-run-on-update logic
 
 Activation runs verification when `lastVerifyVersion !== currentVersion`. The stored version is updated *after* launching the terminal so a crash during launch leaves the next activation able to retry. Bumping the version in `package.json` therefore re-triggers the visible verification for every existing student on their next VS Code restart.
+
+**Windows exception:** the `globalState` stamp is intentionally *not* written when `detectPlatform() === "windows"`. The verification is a no-op on the Windows side, so marking the version as seen would prevent the auto-run terminal from firing when the student opens a WSL window. Leaving globalState unset ensures the first activation inside WSL still sees `lastVerifyVersion !== currentVersion` and runs the terminal.
 
 ### Bundled scripts
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The verification script re-runs automatically on first install and after each ex
 You need to install WSL and Ubuntu first, then connect VS Code to WSL. See the [WSL setup guide](https://eecs280staff.github.io/tutorials/setup_wsl.html).
 
 **Windows: "Not in WSL" status bar warning**
-You have WSL installed, but VS Code is running as a Windows app. The extension shows a "Reopen in WSL" notification on activation, and clicking the **EECS 280: Not in WSL** status bar item also reopens the current folder inside WSL.
+You have WSL installed, but VS Code is running as a Windows app. The extension shows a notification on activation — click **Open in WSL** (no folder open) or **Reopen in WSL** (folder open) to connect. Clicking the **EECS 280: Not in WSL** status bar item does the same thing. Once inside WSL, verification runs automatically.
 
 **macOS: Xcode CLT installation dialog doesn't appear**
 Try running `xcode-select --install` directly in Terminal.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -565,20 +565,22 @@ async function maybeShowWslNotification(
     return;
   }
 
-  const reopenLabel = "Reopen in WSL";
+  const hasFolderOpen =
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders.length > 0;
+  const openLabel = hasFolderOpen ? "Reopen in WSL" : "Open in WSL";
 
   const selection = await vscode.window.showWarningMessage(
     "EECS 280: VS Code is running on Windows, but EECS 280 work should be done inside WSL. " +
-      "Reopen this folder in WSL to use the toolchain you've installed.",
-    reopenLabel,
+      (hasFolderOpen
+        ? "Reopen this folder in WSL to use the toolchain you've installed."
+        : "Open a WSL window to verify your setup and create your project."),
+    openLabel,
     dontShowLabel
   );
 
-  if (selection === reopenLabel) {
-    // remote-wsl.reopenInWSL is the command that powers the blue "><"
-    // button's "Reopen Folder in WSL" action. It reopens the current
-    // folder in a WSL-connected window.
-    await vscode.commands.executeCommand("remote-wsl.reopenInWSL");
+  if (selection === openLabel) {
+    await vscode.commands.executeCommand("eecs280.reopenInWsl");
   } else if (selection === dontShowLabel) {
     await context.workspaceState.update(WSL_NOTIFICATION_DISMISSED_KEY, true);
   }
@@ -679,11 +681,23 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register the "Reopen in WSL" command, used by both the WSL warning
   // notification action button and the status bar in the not-in-WSL state.
-  // We wrap the underlying remote-wsl.reopenInWSL command so we have a
-  // single, stable command id to bind to the status bar.
+  //
+  // When a folder is open, reopen it in WSL. When no folder is open (the
+  // common first-install case where the student hasn't created a project yet),
+  // open a new WSL-connected window instead — remote-wsl.reopenInWSL requires
+  // a folder and silently fails without one.
   const reopenInWslCommand = vscode.commands.registerCommand(
     "eecs280.reopenInWsl",
-    () => vscode.commands.executeCommand("remote-wsl.reopenInWSL")
+    () => {
+      const hasFolderOpen =
+        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders.length > 0;
+      if (hasFolderOpen) {
+        vscode.commands.executeCommand("remote-wsl.reopenInWSL");
+      } else {
+        vscode.commands.executeCommand("remote-wsl.newWindow");
+      }
+    }
   );
   context.subscriptions.push(reopenInWslCommand);
 
@@ -775,7 +789,13 @@ export function activate(context: vscode.ExtensionContext): void {
       );
     }
 
-    context.globalState.update(LAST_VERIFY_VERSION_KEY, currentVersion);
+    // Don't mark this version as seen on Windows-without-WSL. The student
+    // hasn't actually run verification yet — they need to open a WSL window
+    // first. Leaving globalState unset means the auto-run terminal fires
+    // correctly when the extension activates inside that WSL window.
+    if (detectPlatform() !== "windows") {
+      context.globalState.update(LAST_VERIFY_VERSION_KEY, currentVersion);
+    }
   }
 
   // Kick off the silent background check that drives the status bar.


### PR DESCRIPTION
Closes #26

### Summary
 - eecs280.reopenInWsl now uses remote-wsl.newWindow when no folder is open (the typical first-install state), instead   of remote-wsl.reopenInWSL which silently fails without a folder
  - maybeShowWslNotification button label and message body reflect whether a folder is open ("Open in WSL" vs "Reopen in   WSL"), and delegates to eecs280.reopenInWsl so the folder check is centralised                                         - globalState version stamp is skipped on Windows, so the auto-run terminal verification fires correctly when the
  extension activates in the new WSL window

### Test plan

  - Fresh Windows VS Code install, WSL installed, no folder open: popup says "Open in WSL", clicking it opens a new       WSL-connected window, verification terminal fires automatically in that window
  - Windows VS Code with a folder open, WSL installed: popup says "Reopen in WSL", clicking it reopens the folder in WSL   as before                                                                                                              - macOS / native Linux / WSL-connected window: no change in behaviour
                                                                            